### PR TITLE
fix: include sources in source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "outDir": "./lib",
     "removeComments": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "target": "es6",
     "jsx": "react",


### PR DESCRIPTION
When running projects with this library, webpack and source-map-loader,
you get "Failed to parse source map" errors. The source is not included
in the package, while the source maps reference the files.

Added inlineSource: true to tsconfig to include source in source maps.