### PR TITLE
Fixed an hard refresh issues with the AuthorizedRoute

### DIFF
--- a/tests/routeguards/AuthorizedRoute.test.tsx
+++ b/tests/routeguards/AuthorizedRoute.test.tsx
@@ -57,7 +57,7 @@ describe('AuthorizedRoute', () => {
           </PrivateRoute>
 
           <AuthorizedRoute<User>
-            authorizer={(user) => user.isAdmin}
+            authorizer={(user) => !!user?.isAdmin}
             path="/admin"
             exact
           >


### PR DESCRIPTION
When hard refreshing a AuthorizedRoute it would always redirect to the dashboard even if the user is already logged in.

- In AuthorizedRoute changed the state of the Redirect. This state need the from as a location instead of location being the whole state. Now the Redirect looks the same a the PrivateRoute and this doesn't have this problem.